### PR TITLE
Changed URL redirect method

### DIFF
--- a/app/scripts/controllers/eventdetails.js
+++ b/app/scripts/controllers/eventdetails.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     var session_token = getCookie("session_token");

--- a/app/scripts/controllers/frienddetails.js
+++ b/app/scripts/controllers/frienddetails.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     var session_token = getCookie("session_token");

--- a/app/scripts/controllers/friends.js
+++ b/app/scripts/controllers/friends.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     var session_token = getCookie("session_token");

--- a/app/scripts/controllers/join.js
+++ b/app/scripts/controllers/join.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     $scope.submit = function(){

--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     $scope.submit = function(){

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     $scope.token = getCookie("session_token");

--- a/app/scripts/controllers/myevents.js
+++ b/app/scripts/controllers/myevents.js
@@ -17,7 +17,7 @@ angular.module('nudgeWebAppApp')
 
     $scope.go = function(requrl){
         console.log("url switch for " + requrl);
-        $location.url(requrl);
+        $location.path(requrl);
     }
 
     var session_token = getCookie("session_token");


### PR DESCRIPTION
Switched to using $location.path instead of $location.url. This is to
prevent the bug concerning infinite redirects on production servers.
Closes #12